### PR TITLE
Add toDateTime Method for Converting DateOnly Back to DateTime

### DIFF
--- a/lib/date_only.dart
+++ b/lib/date_only.dart
@@ -20,6 +20,11 @@ class DateOnly {
         day: dateTime.day,
       );
 
+  /// toDateTime
+  /// Convert to DateTime
+  /// Warning: Time is set to 00:00:00
+  DateTime toDateTime() => DateTime(year, month, day);
+
   /// factory now
   factory DateOnly.now() => DateOnly.fromDateTime(DateTime.now());
 


### PR DESCRIPTION
This pull request addresses issue #2, which requested the ability to convert DateOnly instances back to DateTime. The changes include:

Adding a toDateTime method in the DateOnly class. This method allows the conversion of a DateOnly instance back to a DateTime object, with the time set to 00:00:00.
The addition of this method enhances the usability of the date_only package by providing the flexibility to revert to the full DateTime format when necessary.

Please review the changes and let me know if any further modifications are needed.